### PR TITLE
Don't ignore if `submoduleName` has an extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = (request, options) => {
   }
 
   const extension = path.extname(submoduleName);
-  if (packageName && submoduleName && !extension) {
+  if (packageName && submoduleName) {
     let packageJson = undefined;
 
     try {


### PR DESCRIPTION
Fix #2 