### PR TITLE
Remove extra logs for optional modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,14 @@ function getPackageJson(packageName) {
   try {
     return require(`${packageName}/package.json`);
   } catch (requireError) {
-    if (requireError.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED")
+    if (requireError.code === "MODULE_NOT_FOUND") {
+      throw requireError;
+    }
+    if (requireError.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") {
       return console.error(
         `Unexpected error while requiring ${packageName}:`, requireError
       );
+    }
   }
 
   // modules's `package.json` does not provide the "./package.json" path at it's


### PR DESCRIPTION
If my module (or my dependency) tests if the optional module present exists with
```js
try {
  require('optional-module')
} catch(e) {
}
```
I get a `console.error` message and no module is resolved. I think it's better just to throw at this point to mimic node.js require. We test error code for `"MODULE_NOT_FOUND"` to be sure that it's a missing module, not a missing export for `package.json`.