### PR TITLE
Throwing an error doesn't work for monorepos

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function getPackageJson(packageName) {
     return require(`${packageName}/package.json`);
   } catch (requireError) {
     if (requireError.code === "MODULE_NOT_FOUND") {
-      throw requireError;
+      return console.error(`Unable to find package.json for ${packageName}`);
     }
     if (requireError.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") {
       return console.error(


### PR DESCRIPTION
We were noticing that with `gatsby-source-contentful`, it was unable to find the `package.json` (not sure why), but there was nothing being printed out. If the error is ignored, jest is able to handle it perfectly fine.