### PR TITLE
Fix handling absolute paths on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = (request, options) => {
   const isNodeModuleRequest =
   !(
     request.startsWith(".") ||
-    request.startsWith("/") ||
+    path.isAbsolute(request) ||
     request.startsWith("jest-sequencer")
   );
 


### PR DESCRIPTION
We have `jest.config.js` that looks somewhat like this:
```js
module.exports = {
    rootDir: './',
    setupFiles: [
        '<rootDir>/scripts/someSetupFile.js',
    ],
    resolver: 'jest-node-exports-resolver',
}
```
On Windows the resolver is called with path like `'C:/pathToRepo/scripts/someSetupFile.js'`, which is causing an error:
> Module \<rootDir>/scripts/someSetupFile.js in the setupFiles option was not found.
> \<rootDir> is: C:\pathToRepo

An alternative fix would be to wrap everything in `try` and in `catch` return `defaultResolver`.